### PR TITLE
Fixes #4: Support ng-di-mocks.js in Node

### DIFF
--- a/lib/ng-di-mocks.js
+++ b/lib/ng-di-mocks.js
@@ -14,15 +14,16 @@
  * Namespace from 'angular-mocks.js' which contains testing related code.
  */
 
-(function(window){
-  if(!window.jasmine){
-    return;
- }
-  var angular = window.di,
-      jasmine = window.jasmine;
+void function(window){
+  var window = window || {}
+  var jasmine = window.jasmine
+  var angular = window.angular || require('./ng-di')
+  if (!jasmine || !angular) {
+    throw Error('Jasmine and Amgular should be available globally'
+      + ' when you init these mocks.')
+  }
 
   angular.mock = {};
-
   window.afterEach(function() {
     var spec = getCurrentSpec();
     var injector = spec.$injector;
@@ -159,4 +160,4 @@
     }
     return isSpecRunning() ? workFn() : workFn;
   };
-})(this);
+}(typeof global == 'object' ? global : this);


### PR DESCRIPTION
Much nicer way than the init one, and works wonderfully with node, been using it in the past few days.

I think we should be wary of overly using global though.
Two other ways would be:
#### 2)

``` js
var mocks = require('ng-di/mocks')
var module = mocks.module
var inject = mocks.inject
```
#### 3)

``` js
var mocks = require('ng-di/mocks')
beforeEach(mocks.module(['myModule']))
beforeEach(mocks.inject(function(){"..."}))
```

I'm not sure I like these either.

Which one do you like best?
Do you have any better ideas?
### Disclaimer

Didn't yet test this in the browser. Btw, do we have tests to check whether it works in both environments?
